### PR TITLE
Do not change permissions of existing target dir when --no-overwrite-dir is given

### DIFF
--- a/src/extract.c
+++ b/src/extract.c
@@ -1158,31 +1158,6 @@ extract_dir (char *file_name, char typeflag)
 			  repair_delayed_set_stat (file_name, &st);
 			  return true;
 			}
-		      else if (old_files_option == NO_OVERWRITE_DIR_OLD_FILES)
-			{
-			  /* Temporarily change the directory mode to a safe
-			     value, to be able to create files in it, should
-			     the need be.
-			  */
-			  mode = safe_dir_mode (&st);
-			  status = fd_chmod (-1, file_name, mode,
-					     AT_SYMLINK_NOFOLLOW, DIRTYPE);
-			  if (status == 0)
-			    {
-			      /* Store the actual directory mode, to be restored
-				 later.
-			      */
-			      current_stat_info.stat = st;
-			      current_mode = mode & ~ current_umask;
-			      current_mode_mask = MODE_RWX;
-			      atflag = AT_SYMLINK_NOFOLLOW;
-			      break;
-			    }
-			  else
-			    {
-			      chmod_error_details (file_name, mode);
-			    }
-			}
 		      break;
 		    }
 		}

--- a/tests/extrac23.at
+++ b/tests/extrac23.at
@@ -21,16 +21,23 @@ AT_KEYWORDS([extract extrac23 no-overwrite-dir])
 # Description: Implementation of the --no-overwrite-dir option was flawed in
 # tar versions up to 1.32.90.  This option is intended to preserve metadata
 # of existing directories.  In fact it worked only for non-empty directories.
-# Moreover, if the actual directory was owned by the user tar runs as and the
-# S_IWUSR bit was not set in its actual permissions, tar failed to create files
-# in it.
+# Moreover, the first fix caused some permissions (depending on the current
+# umask) and modification times to get overwritten when the directory had not
+# the S_IWUSR bit set in its actual permissions, and also caused failure
+# to extract an empty directory if the already existing directory had not
+# the S_IWUSR bit set in its actual permissions and changing the permissions
+# was not possible.
 #
 # Reported by: Michael Kaufmann <mail@michael-kaufmann.ch>
 # References: <20200207112934.Horde.anXzYhAj2CHiwUrw5CuT0G-@webmail.michael-kaufmann.ch>,
 #   https://lists.gnu.org/archive/html/bug-tar/2020-02/msg00003.html
+#
+# Reported by: Nate Simon <njsimon10@gmail.com>
+# References: <e09b5362-548a-40b6-beec-99add9a88e11@gmail.com>,
+#   https://lists.gnu.org/archive/html/bug-tar/2024-11/msg00006.html
 
 AT_TAR_CHECK([
-# Test if the directory permissions are restored properly.
+# Test if the directory permissions are preserved properly.
 mkdir dir
 chmod 755 dir
 tar cf a.tar dir
@@ -38,21 +45,16 @@ chmod 777 dir
 tar -xf a.tar --no-overwrite-dir
 genfile --stat=mode.777 dir
 
-# Test if temporary permissions are set correctly to allow the owner
-# to write to the directory.
-genfile --file dir/file
+# Test if the directory permissions are preserved even if it is not writable.
+chmod 755 dir
 tar cf a.tar dir
-rm dir/file
-chmod 400 dir
+chmod 444 dir
+umask 066
 tar -xf a.tar --no-overwrite-dir
 genfile --stat=mode.777 dir
-chmod 700 dir
-find dir
 ],
 [0],
 [777
-400
-dir
-dir/file
+444
 ])
 AT_CLEANUP


### PR DESCRIPTION
tar tries to preserve the permissions of an existing target directory when `--no-overwrite-dir` is given by saving them, changing the permissions to a value that allows writing, and restoring them back at the end. This can lead to failures when it is not allowed to change the permissions. Remove the setting of permissions to fix this problem, making sure that existing directories are writable when `--no-overwrite-dir` is set is now the responsibility of the user.

https://lists.gnu.org/archive/html/bug-tar/2025-01/msg00000.html